### PR TITLE
Nette DI: suspicious dumping of objects IPub\WebSocketsZMQ\Configuration when generating the container

### DIFF
--- a/src/IPub/WebSocketsZMQ/Configuration.php
+++ b/src/IPub/WebSocketsZMQ/Configuration.php
@@ -36,22 +36,22 @@ final class Configuration
 	/**
 	 * @var string
 	 */
-	private $host;
+	public $host;
 
 	/**
 	 * @var int
 	 */
-	private $port;
+	public $port;
 
 	/**
 	 * @var bool
 	 */
-	private $persistent;
+	public $persistent;
 
 	/**
 	 * @var string
 	 */
-	private $protocol;
+	public $protocol;
 
 	/**
 	 * @param string $host


### PR DESCRIPTION
Nette DI since v3.2 does not allow private or protected properties.